### PR TITLE
Use rm -rf over forcing the output to be 0

### DIFF
--- a/build.command
+++ b/build.command
@@ -7,7 +7,7 @@ ICON_LABEL="Momiji \nDownloader"
 BUNDLE_IDENTIFIER="Wowfunhappy.Momiji-Downloader"
 OUTPUT_DIR="${TITLE}.prefPane"
 
-rm -r "$OUTPUT_DIR" || true
+rm -rf "$OUTPUT_DIR"
 
 # Create necessary directories
 mkdir -p "${OUTPUT_DIR}/Contents/MacOS"


### PR DESCRIPTION
A very small change that does not fix anything, but *should* prevent rm from showing an error, when you haven't even tried to build in the first place. Maybe it's something done for legacy compatibility? I'm not sure. Hopefully it breaks nothing.